### PR TITLE
DMA error(s) workaround, improving socket input parsing

### DIFF
--- a/src/processor.cc
+++ b/src/processor.cc
@@ -6,14 +6,16 @@
 
 StreamProcessor::StreamProcessor(size_t max_size_) : 
   max_size(max_size_),
-  tbb::filter(parallel)
+  tbb::filter(parallel),
+  nbPackets(0)
 { fprintf(stderr,"Created transform filter at 0x%llx \n",(unsigned long long)this);}  
 StreamProcessor::~StreamProcessor(){
   //  fprintf(stderr,"Wrote %d muons \n",totcount);
 }
 
-Slice* process(Slice& input, Slice& out)
+Slice* StreamProcessor::process(Slice& input, Slice& out)
 {
+  nbPackets++;
   int bsize = sizeof(block1);
   if((input.size()-constants::orbit_trailer_size)%bsize!=0){
     std::cout << "WARNING::frame size not a multiple of block size. Will be skipped. Size="
@@ -61,7 +63,7 @@ Slice* process(Slice& input, Slice& out)
     uint32_t bxcount = std::max(mAcount,mBcount);
     if(bxcount == 0) {
       p+=bsize;
-      std::cout << "WARNING::detected a bx with zero muons, this should not happen" << std::endl; 
+      std::cout << '#' << nbPackets << ": WARNING::detected a bx with zero muons, this should not happen. Packet is skipped." << std::endl; 
       continue;
     }
 

--- a/src/processor.h
+++ b/src/processor.h
@@ -5,13 +5,20 @@
     
 //reformatter
 
+class Slice;
+
 class StreamProcessor: public tbb::filter {
 public:
   StreamProcessor(size_t);
   void* operator()( void* item )/*override*/;
   ~StreamProcessor();
+
+private:
+  Slice* process(Slice& input, Slice& out);
+
 private:
   size_t max_size;
+  uint64_t nbPackets;
 };
 
 #endif

--- a/src/wzdma_input.cc
+++ b/src/wzdma_input.cc
@@ -91,6 +91,12 @@ inline ssize_t WZDmaInputFilter::read_packet(char **buffer)
       if (errno == EIO) {
         std::cerr << "#" << ncalls << ": Trying to restart DMA (attempt #" << tries << "): ";
         wz_stop_dma( &dma );
+        wz_close( &dma );
+
+        // Initialize the DMA subsystem 
+        if ( wz_init( &dma ) < 0 ) {
+          throw std::system_error(errno, std::system_category(), "Cannot initialize WZ DMA device");
+        }
 
         if (wz_start_dma( &dma ) < 0) {
           throw std::system_error(errno, std::system_category(), "Cannot start WZ DMA device");


### PR DESCRIPTION
During DMA error recovery memory unmap and map added. Seems to be better.
Making parsing of socket input more robust. 