### PR TITLE
Synchronisation with P5 system

### DIFF
--- a/scripts/fileMover.py
+++ b/scripts/fileMover.py
@@ -7,19 +7,23 @@ if __name__ == "__main__":
     import os
 
     while True:
-        onlyfiles = [f for f in listdir('/fff/ramdisk/scdaq') if isfile(join('/fff/ramdisk/scdaq', f)) and f.endswith('.dat')]
-        if len(onlyfiles)==0:
-            print "waiting for new file..."
-            time.sleep(30)
-        print onlyfiles
-        for f in onlyfiles:
-            full_filename = join('/fff/ramdisk/scdaq', f)
-            outfile = f+'.bz2'
-            dest_name = join('/fff/output/scdaq',outfile)
-            command = "lbzip2 "+full_filename+" -c > "+dest_name
-            print "compressing "+full_filename
-            retval = os.system(command)
-            if retval==0:
-                command = "rm "+full_filename
-                print "deleting "+full_filename
+        try:
+            onlyfiles = [f for f in listdir('/fff/ramdisk/scdaq') if isfile(join('/fff/ramdisk/scdaq', f)) and f.endswith('.dat')]
+            if len(onlyfiles)==0:
+                print "waiting for new file..."
+                time.sleep(30)
+            print onlyfiles
+            for f in onlyfiles:
+                full_filename = join('/fff/ramdisk/scdaq', f)
+                outfile = f+'.bz2'
+                dest_name = join('/fff/output/scdaq',outfile)
+                command = "lbzip2 "+full_filename+" -c > "+dest_name
+                print "compressing "+full_filename
                 retval = os.system(command)
+                if retval==0:
+                    command = "rm "+full_filename
+                    print "deleting "+full_filename
+                    retval = os.system(command)
+        except OSError as err:
+            print err
+            time.sleep(600)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -7,21 +7,23 @@ cd ../src
 
 echo "Clearing caches..."
 sync
-echo 3 > /proc/sys/vm/drop_caches
+echo 3 | sudo tee /proc/sys/vm/drop_caches > /dev/null
+
+umask 000 # Files and folders we create should be world accessible
 
 while true 
 do
     echo "Starting scdaq..."
-    ./scdaq 2>&1 | logger --stderr --tag scdaq --id
+    ./scdaq 2>&1 | logger --tag scdaq --id -p user.debug
     echo "Resetting the board..."
     ../scripts/reset-firmware.sh
     echo "Clearing caches..."
     sync
-    echo 3 > /proc/sys/vm/drop_caches
+    echo 3 | sudo tee /proc/sys/vm/drop_caches > /dev/null
     echo "Waiting 30 seconds..."
-    for ((i=30; i>0; i--)) 
+    for ((i=30; i>0; i=i-15)) 
     do
-	echo "$i"
-	sleep 1
+	echo "$i..."
+	sleep 15
     done
 done

--- a/scripts/vivado/reset_server.tcl
+++ b/scripts/vivado/reset_server.tcl
@@ -7,9 +7,9 @@ proc init_hw {} {
     current_hw_target [get_hw_targets */xilinx_tcf/Xilinx/1234-tulA]
     set_property PARAM.FREQUENCY 15000000 [get_hw_targets */xilinx_tcf/Xilinx/1234-tulA]
     open_hw_target
-    set_property PROGRAM.FILE {/home/scouter/bitfiles/eight_links_zs/top.bit} [get_hw_devices xcku115_0]
-    set_property PROBES.FILE {/home/scouter/bitfiles/eight_links_zs/top.ltx} [get_hw_devices xcku115_0]
-    set_property FULL_PROBES.FILE {/home/scouter/bitfiles/eight_links_zs/top.ltx} [get_hw_devices xcku115_0]
+    set_property PROGRAM.FILE {/home/scouter/bitfiles/use_with_vivado_2018.2/eight_links_zs_lids_from_protocol/top.bit} [get_hw_devices xcku115_0]
+    set_property PROBES.FILE {/home/scouter/bitfiles/use_with_vivado_2018.2/eight_links_zs_lids_from_protocol/top.ltx} [get_hw_devices xcku115_0]
+    set_property FULL_PROBES.FILE {/home/scouter/bitfiles/use_with_vivado_2018.2/eight_links_zs_lids_from_protocol/top.ltx} [get_hw_devices xcku115_0]
     current_hw_device [get_hw_devices xcku115_0]
     refresh_hw_device [lindex [get_hw_devices xcku115_0] 0]
 }

--- a/src/scdaq.conf
+++ b/src/scdaq.conf
@@ -19,7 +19,7 @@ dma_packet_buffer_size:1048576
 dma_number_of_packet_buffers:1000
 
 # Print report each N packets, use 0 to disable
-packets_per_report:1000
+packets_per_report:200000
 #packets_per_report:1
 
 
@@ -36,7 +36,7 @@ output_filename_base:/fff/BU0/ramdisk/scdaq
 max_file_size:8589934592
 
 # Always write data to a file regardless of the run status, usefull for debugging
-output_force_write:yes
+output_force_write:no
 
 
 # Elastics processor

--- a/src/session.h
+++ b/src/session.h
@@ -102,12 +102,12 @@ private:
     if (!error)
     {
       std::string_view input(data_, bytes_transferred);
-      LOG(INFO) << "Run control: Received: '" << input << '\'';
+      LOG(DEBUG) << "Run control: Received: '" << input << '\'';
 
       bytes_transferred = process_command(input, data_, max_length);
 
       std::string_view output(data_, bytes_transferred);
-      LOG(INFO) << "Run control: Sending:  '" << output << '\'';
+      LOG(DEBUG) << "Run control: Sending:  '" << output << '\'';
 
       boost::asio::async_write(socket_,
           boost::asio::buffer(data_, bytes_transferred),

--- a/src/tools.h
+++ b/src/tools.h
@@ -68,7 +68,7 @@ inline bool create_directories(std::string& path)
       int dir_len = p - last_backslash - 1;
       if (dir_len > 0) {
         *p = 0;
-        if (mkdir(tmp, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) < 0 && (errno != EEXIST)) {
+        if (mkdir(tmp, S_IRWXU | S_IRWXG | S_IRWXO) < 0 && (errno != EEXIST)) {
           return false;
         }
         *p = '/';


### PR DESCRIPTION
This synchronises the repo with the situation at P5. The changes aren't major:
* we can now run `scdaq` as unprivileged users
* fileMover doesn't crash if the target directories don't yet exist
* I updated the path to the debug probes for the reset server
* Logging is now less noisy (I also demoted `scdaq` to debug log level as I couldn't get a few of the statements there under control)