### PR TITLE
Replacing tbb::zero_allocator with aligned allocator

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ CXXFLAGS = -std=c++11 -Wall -Wextra -O0 -g -rdynamic
 #CXXFLAGS = -std=c++11 -Wall -Wextra -g -rdynamic
 
 CFLAGS = $(CXXFLAGS)
-LDFLAGS = -ltbb -lboost_thread -lcurl
+LDFLAGS = -ltbb -ltbbmalloc -lboost_thread -lcurl
 
 CPPFLAGS = -I. -Iwzdma
 


### PR DESCRIPTION
MicronDMA requires the buffers to be aligned to 32 bytes (256 bits)...