### PR TITLE
Updated paths for reset server

### DIFF
--- a/scripts/vivado/reset_server.sh
+++ b/scripts/vivado/reset_server.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-source /opt/Xilinx/Vivado/2018.2/settings64.sh
+source /opt/Xilinx/Vivado_Lab/2018.3/settings64.sh
 vivado -mode batch -source reset_server.tcl

--- a/scripts/vivado/reset_server.tcl
+++ b/scripts/vivado/reset_server.tcl
@@ -7,9 +7,9 @@ proc init_hw {} {
     current_hw_target [get_hw_targets */xilinx_tcf/Xilinx/1234-tulA]
     set_property PARAM.FREQUENCY 15000000 [get_hw_targets */xilinx_tcf/Xilinx/1234-tulA]
     open_hw_target
-    set_property PROGRAM.FILE {/home/scouter/bitfiles/use_with_vivado_2018.2/eight_links_zs_lids_from_protocol/top.bit} [get_hw_devices xcku115_0]
-    set_property PROBES.FILE {/home/scouter/bitfiles/use_with_vivado_2018.2/eight_links_zs_lids_from_protocol/top.ltx} [get_hw_devices xcku115_0]
-    set_property FULL_PROBES.FILE {/home/scouter/bitfiles/use_with_vivado_2018.2/eight_links_zs_lids_from_protocol/top.ltx} [get_hw_devices xcku115_0]
+    set_property PROGRAM.FILE {/home/scouter/bitfiles/currently_used/top.bit} [get_hw_devices xcku115_0]
+    set_property PROBES.FILE  {/home/scouter/bitfiles/currently_used/top.ltx} [get_hw_devices xcku115_0]
+    set_property FULL_PROBES.FILE {/home/scouter/bitfiles/currently_used/top.ltx} [get_hw_devices xcku115_0]
     current_hw_device [get_hw_devices xcku115_0]
     refresh_hw_device [lindex [get_hw_devices xcku115_0] 0]
 }


### PR DESCRIPTION
A few changes:
* We're using Vivado lab edition at P5, so that's what we need to source and start.
* We use the convention that the directory containing the currently deployed bitfile (and ltx files) always has the symlink ~scouter/bitfiles/currently_used/ pointed at it, so the reset server should use those by default.
